### PR TITLE
Add UTF-8 support to html() method

### DIFF
--- a/src/Embed.php
+++ b/src/Embed.php
@@ -325,7 +325,7 @@ class Embed
     {
         $script = null;
         $doc = new DOMDocument();
-        $doc->loadHTML("<html><body>$html</body></html>", LIBXML_NOERROR);
+        $doc->loadHTML("<?xml encoding='utf-8' ?><html><body>$html</body></html>", LIBXML_NOERROR);
         $body = $doc->documentElement->lastChild;
 
         if (!$body || ($body && !$body->firstChild)) {


### PR DESCRIPTION
Adding UTF-8 support to extractOEmbedHtml() method.

when trying to use $embed->html() for Arabic language I got something like `Ø£Ù‡Ù… ÙÙŠØ¯ÙŠÙˆ`, so we need to add support to UTF-8. This PR fix this issue.