### PR TITLE
Factory: Fix passing config

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -14,8 +14,9 @@ class Factory
     public function __construct(?array $config = null)
     {
         if (is_null($config)) {
-            $this->config = require('./resources/config.php');
+            $config = require('./resources/config.php');
         }
+        $this->config = $config;
     }
 
     /**


### PR DESCRIPTION
When not using Laravel, there is no `resources/` directory but passing a custom config would have no effect.